### PR TITLE
Switch underlying dependency to the official `hubspot/hubspot-php`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     ],
     "require": {
         "php": "^7.1.3|^8.0",
-        "illuminate/notifications": "5.7.*|5.8.*|^6.0|^7.0|^8.0",
-        "ryanwinchester/hubspot-php": "^1.2"
+        "hubspot/hubspot-php": "^3.1",
+        "illuminate/notifications": "5.7.*|5.8.*|^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",

--- a/src/Channels/HubspotChannel.php
+++ b/src/Channels/HubspotChannel.php
@@ -40,7 +40,7 @@ class HubspotChannel
 
         $message = $notification->toHubspot($notifiable);
 
-        return $this->hubspot->singleEmail()->send(
+        return $this->hubspot->transactionalEmail()->send(
             $message->templateId,
             array_merge(['to' => $to], $message->messageProperties),
             $message->contactProperties,

--- a/tests/NotificationHubspotChannelTest.php
+++ b/tests/NotificationHubspotChannelTest.php
@@ -9,7 +9,7 @@ use Illuminate\Notifications\Notification;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use SevenShores\Hubspot\Factory;
-use SevenShores\Hubspot\Resources\SingleEmail;
+use SevenShores\Hubspot\Resources\TransactionalEmail;
 
 class NotificationHubspotChannelTest extends TestCase
 {
@@ -20,11 +20,11 @@ class NotificationHubspotChannelTest extends TestCase
 
         // Arrange.
         $hubspot = Mockery::mock(Factory::class);
-        $singleEmail = Mockery::mock(SingleEmail::class);
+        $singleEmail = Mockery::mock(TransactionalEmail::class);
         $channel = new HubspotChannel($hubspot);
 
         // Assert.
-        $hubspot->shouldReceive('singleEmail')->andReturn($singleEmail);
+        $hubspot->shouldReceive('transactionalEmail')->andReturn($singleEmail);
         $singleEmail->shouldReceive('send')->with(
             '12134249933',
             ['to' => 'kani.robinson@digitalrisks.co.uk'],


### PR DESCRIPTION
Replaces legacy API usage ([`singleEmail`](https://legacydocs.hubspot.com/docs/methods/email/transactional_email/single-send-overview)) to new API usage ([`transactionalEmail`](https://developers.hubspot.com/docs/api/marketing/transactional-emails)).

This allows this package to be used with Guzzle v7 as well.