### PR TITLE
Laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         }
     ],
     "require": {
-        "php": "^7.1.3|^8.0",
+        "php": "^8.0.2",
         "hubspot/hubspot-php": "^3.1",
-        "illuminate/notifications": "5.7.*|5.8.*|^6.0|^7.0|^8.0"
+        "illuminate/notifications": "^9.0"
     },
     "require-dev": {
-        "mockery/mockery": "^1.0",
+        "mockery/mockery": ">=1.3.3 <1.4||^1.4.2",
         "phpunit/phpunit": "^9.5.7"
     },
     "autoload": {


### PR DESCRIPTION
- Remove PHP7 from `composer.json`
- Allow `mockery/mockery`:`>=1.3.3 <1.4||^1.4.2` in `composer.json`
- Allow `illuminate/notifications`:`^9.0` in `composer.json`