### PR TITLE
Change HubSpot authentication method to Private Apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [2.0.0]
+
+### Changed
+
+- Replace HubSpot authentication method from API Key to Private Apps

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add your Hubspot key to your `config/services.php`:
 // config/services.php
 ...
 'hubspot' => [
-    'key' => env('HUBSPOT_KEY', null),
+    'app_access_token' => env('HUBSPOT_APP_ACCESS_TOKEN', null),
     'template_id' => env('TEMPLATE_NAME_ID', null)
 ],
 ...

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -20,7 +20,8 @@ class ServiceProvider extends BaseServiceProvider
             $service->extend('hubspot', function ($app) {
                 return new Channels\HubspotChannel(
                     new Factory([
-                        'key' => $this->app['config']['services.hubspot.key'],
+                        'key' => $this->app['config']['services.hubspot.app_access_token'],
+                        'oauth2' => true,
                     ])
                 );
             });


### PR DESCRIPTION
HubSpot is sunsetting the API Key access method - https://developers.hubspot.com/changelog/upcoming-api-key-sunset


This PR will change the authentication method to [Private Apps](https://developers.hubspot.com/docs/api/private-apps) instead